### PR TITLE
fix: fix generating load trigger notification when itemCount is less than prefetchIndex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- [[#7](https://github.com/xsahil03x/super_paging/issues/7)] Fix generating load trigger notification when `itemCount` is less than `prefetchIndex`.
+
 ## 0.1.0
 
 - Initial Release.

--- a/lib/src/widget/bidirectional_paging_list_view.dart
+++ b/lib/src/widget/bidirectional_paging_list_view.dart
@@ -471,16 +471,23 @@ class _BidirectionalPagingListViewState<Key, Value>
       // notifications.
       if (fetchIndex == null) return;
 
-      // Check if the index corresponds to near the top or bottom based on the
-      // 'reverse' flag.
-      final nearTop =
-          reverse ? index == itemCount - fetchIndex : index == fetchIndex;
-      final nearBottom =
-          reverse ? index == fetchIndex : index == itemCount - fetchIndex;
+      // Generate notifications at the beginning and end of the list if the
+      // [itemCount] is less than [prefetchIndex].
+      if (itemCount < fetchIndex) {
+        if (index == 0) onBuildingPrependLoadTriggerItem?.call();
+        if (index == itemCount - 1) onBuildingAppendLoadTriggerItem?.call();
+        return;
+      }
 
-      // Generate prepend notification.
+      // Check if the index corresponds to near the top or bottom of the list
+      // based on the [reverse] flag.
+      final (nearTop, nearBottom) = switch (reverse) {
+        true => (index == itemCount - fetchIndex, index == fetchIndex),
+        false => (index == fetchIndex, index == itemCount - fetchIndex),
+      };
+
+      // Generate notifications.
       if (nearTop) onBuildingPrependLoadTriggerItem?.call();
-      // Generate append notification.
       if (nearBottom) onBuildingAppendLoadTriggerItem?.call();
     }
 

--- a/lib/src/widget/bidirectional_paging_list_view.dart
+++ b/lib/src/widget/bidirectional_paging_list_view.dart
@@ -463,17 +463,17 @@ class _BidirectionalPagingListViewState<Key, Value>
   }) {
     final items = pages.items;
     final itemCount = items.length;
-    final fetchIndex = pager.config.prefetchIndex;
+    final prefetchIndex = pager.config.prefetchIndex;
 
     // Helper function to generate prepend and append load trigger notifications
     void generatePrependAppendLoadTriggerNotification(int index) {
       // If there is no prefetch index, we don't need to generate any
       // notifications.
-      if (fetchIndex == null) return;
+      if (prefetchIndex == null) return;
 
       // Generate notifications at the beginning and end of the list if the
       // [itemCount] is less than [prefetchIndex].
-      if (itemCount < fetchIndex) {
+      if (prefetchIndex > itemCount) {
         if (index == 0) onBuildingPrependLoadTriggerItem?.call();
         if (index == itemCount - 1) onBuildingAppendLoadTriggerItem?.call();
         return;
@@ -482,8 +482,8 @@ class _BidirectionalPagingListViewState<Key, Value>
       // Check if the index corresponds to near the top or bottom of the list
       // based on the [reverse] flag.
       final (nearTop, nearBottom) = switch (reverse) {
-        true => (index == itemCount - fetchIndex, index == fetchIndex),
-        false => (index == fetchIndex, index == itemCount - fetchIndex),
+        true => (index == itemCount - prefetchIndex, index == prefetchIndex),
+        false => (index == prefetchIndex, index == itemCount - prefetchIndex),
       };
 
       // Generate notifications.

--- a/lib/src/widget/paging_sliver_list.dart
+++ b/lib/src/widget/paging_sliver_list.dart
@@ -265,20 +265,29 @@ class _PagingSliverListState<Key, Value>
     final itemCount = items.length;
     final prefetchIndex = pager.config.prefetchIndex;
 
+    // Helper function to generate prepend and append load trigger notifications
     void generatePrependAppendLoadTriggerNotification(int index) {
       // If there is no prefetch index, we don't have to generate any
       // notification.
       if (prefetchIndex == null) return;
 
-      // Generate prepend notification.
-      if (index == prefetchIndex) {
-        onBuildingPrependLoadTriggerItem?.call();
+      // Generate notifications at the beginning and end of the list if the
+      // [itemCount] is less than [prefetchIndex].
+      if (itemCount < prefetchIndex) {
+        if (index == 0) onBuildingPrependLoadTriggerItem?.call();
+        if (index == itemCount - 1) onBuildingAppendLoadTriggerItem?.call();
+        return;
       }
 
-      // Generate append notification.
-      if (index == itemCount - prefetchIndex) {
-        onBuildingAppendLoadTriggerItem?.call();
-      }
+      // Check if the index corresponds to near the top or bottom of the list.
+      final (nearTop, nearBottom) = (
+        index == prefetchIndex,
+        index == itemCount - prefetchIndex,
+      );
+
+      // Generate notifications.
+      if (nearTop) onBuildingPrependLoadTriggerItem?.call();
+      if (nearBottom) onBuildingAppendLoadTriggerItem?.call();
     }
 
     final itemBuilder = widget.itemBuilder;

--- a/lib/src/widget/paging_sliver_list.dart
+++ b/lib/src/widget/paging_sliver_list.dart
@@ -273,7 +273,7 @@ class _PagingSliverListState<Key, Value>
 
       // Generate notifications at the beginning and end of the list if the
       // [itemCount] is less than [prefetchIndex].
-      if (itemCount < prefetchIndex) {
+      if (prefetchIndex > itemCount) {
         if (index == 0) onBuildingPrependLoadTriggerItem?.call();
         if (index == itemCount - 1) onBuildingAppendLoadTriggerItem?.call();
         return;


### PR DESCRIPTION
## Description

This pull request includes changes to improve the handling of load trigger notifications and updates to the changelog. The most important changes include fixing the generation of load trigger notifications when the `itemCount` is less than `prefetchIndex` and updating the changelog to reflect this fix.

Improvements to load trigger notifications:

* [`lib/src/widget/bidirectional_paging_list_view.dart`](diffhunk://#diff-5dd76539623b968ae0185aa313e801272544b468d313315a088abbaeec84747bL466-L483): Fixed the generation of load trigger notifications when `itemCount` is less than `prefetchIndex` by adding conditions to handle this case and updating the logic for checking indices.
* [`lib/src/widget/paging_sliver_list.dart`](diffhunk://#diff-aae478a924c7ed2a89681ad5fea9ad8bac894cc0816e32b667fd4114f81cdcc5R268-R290): Added similar logic to handle the case when `itemCount` is less than `prefetchIndex` and updated the conditions for generating load trigger notifications.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore