### PR TITLE
fix: fix big prefetch index not working for prepending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Upcoming
 
+- [[#11]](https://github.com/xsahil03x/super_paging/issues/11) Fix generating prepend load trigger notification when `prefetchIndex` is bigger than the items visible on the screen.
 - [[#7](https://github.com/xsahil03x/super_paging/issues/7)] Fix generating load trigger notification when `itemCount` is less than `prefetchIndex`.
 - Added support for the `Pager.refresh` method to accept an optional `refreshKey` parameter.
 

--- a/lib/src/page_fetcher.dart
+++ b/lib/src/page_fetcher.dart
@@ -94,6 +94,9 @@ class PageFetcher<Key, Value> extends ValueNotifier<PagingState<Key, Value>> {
         log.fine('Initial load cancelled');
       },
       () async {
+        // Skip load if already in a loading state.
+        if (value.getLoadState(LoadType.refresh) case Loading()) return;
+
         // Update load state to loading.
         value = value.setLoading(LoadType.refresh);
 
@@ -144,6 +147,9 @@ class PageFetcher<Key, Value> extends ValueNotifier<PagingState<Key, Value>> {
           loadType != LoadType.refresh,
           'Use doInitialLoad for LoadType == refresh',
         );
+
+        // Skip load if already in a loading state.
+        if (value.getLoadState(loadType) case Loading()) return;
 
         final loadKey = _nextLoadKeyOrNull(loadType);
         if (loadKey == null) return;

--- a/lib/src/widget/bidirectional_paging_list_view.dart
+++ b/lib/src/widget/bidirectional_paging_list_view.dart
@@ -348,34 +348,20 @@ class _BidirectionalPagingListViewState<Key, Value>
                 topPages,
                 reverse: true,
                 onBuildingPrependLoadTriggerItem: () {
-                  final canMakeRequest = prependLoadState.maybeMap(
-                    notLoading: (it) => !it.endOfPaginationReached,
-                    orElse: () => false,
-                  );
-
-                  if (canMakeRequest) {
-                    // Schedules the request for the end of this frame.
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      pager.load(LoadType.prepend);
-                    });
-                  }
+                  // Schedules the request for the end of this frame.
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    pager.load(LoadType.prepend);
+                  });
                 },
                 onBuildingAppendLoadTriggerItem: () {
                   // If the bottom list contain items, we don't need to handle
                   // append here.
                   if (!bottomPages.isListEmpty) return;
 
-                  final canMakeRequest = appendLoadState.maybeMap(
-                    notLoading: (it) => !it.endOfPaginationReached,
-                    orElse: () => false,
-                  );
-
-                  if (canMakeRequest) {
-                    // Schedules the request for the end of this frame.
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      pager.load(LoadType.append);
-                    });
-                  }
+                  // Schedules the request for the end of this frame.
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    pager.load(LoadType.append);
+                  });
                 },
               ),
             ),
@@ -392,30 +378,16 @@ class _BidirectionalPagingListViewState<Key, Value>
                   // prepend here.
                   if (!topPages.isListEmpty) return;
 
-                  final canMakeRequest = prependLoadState.maybeMap(
-                    notLoading: (it) => !it.endOfPaginationReached,
-                    orElse: () => false,
-                  );
-
-                  if (canMakeRequest) {
-                    // Schedules the request for the end of this frame.
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      pager.load(LoadType.prepend);
-                    });
-                  }
+                  // Schedules the request for the end of this frame.
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    pager.load(LoadType.prepend);
+                  });
                 },
                 onBuildingAppendLoadTriggerItem: () {
-                  final canMakeRequest = appendLoadState.maybeMap(
-                    notLoading: (it) => !it.endOfPaginationReached,
-                    orElse: () => false,
-                  );
-
-                  if (canMakeRequest) {
-                    // Schedules the request for the end of this frame.
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      pager.load(LoadType.append);
-                    });
-                  }
+                  // Schedules the request for the end of this frame.
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    pager.load(LoadType.append);
+                  });
                 },
               ),
             ),
@@ -471,24 +443,16 @@ class _BidirectionalPagingListViewState<Key, Value>
       // notifications.
       if (prefetchIndex == null) return;
 
-      // Generate notifications at the beginning and end of the list if the
-      // [itemCount] is less than [prefetchIndex].
-      if (prefetchIndex > itemCount) {
-        if (index == 0) onBuildingPrependLoadTriggerItem?.call();
-        if (index == itemCount - 1) onBuildingAppendLoadTriggerItem?.call();
-        return;
-      }
-
-      // Check if the index corresponds to near the top or bottom of the list
-      // based on the [reverse] flag.
-      final (nearTop, nearBottom) = switch (reverse) {
-        true => (index == itemCount - prefetchIndex, index == prefetchIndex),
-        false => (index == prefetchIndex, index == itemCount - prefetchIndex),
+      // Check if the index is near the edge of the list based on the prefetch
+      // index and the direction of the list.
+      final (shouldPrependItems, shouldAppendItems) = switch (reverse) {
+        true => (index >= itemCount - prefetchIndex, index <= prefetchIndex),
+        false => (index <= prefetchIndex, index >= itemCount - prefetchIndex),
       };
 
       // Generate notifications.
-      if (nearTop) onBuildingPrependLoadTriggerItem?.call();
-      if (nearBottom) onBuildingAppendLoadTriggerItem?.call();
+      if (shouldPrependItems) onBuildingPrependLoadTriggerItem?.call();
+      if (shouldAppendItems) onBuildingAppendLoadTriggerItem?.call();
     }
 
     final separatorBuilder = widget.separatorBuilder;


### PR DESCRIPTION
## Description
Fixes generating prepend load trigger notification when `prefetchIndex` is bigger than the items visible on the screen.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore