### PR TITLE
ci: add pub publish workflow

### DIFF
--- a/.github/workflows/pub_publish.yaml
+++ b/.github/workflows/pub_publish.yaml
@@ -1,0 +1,25 @@
+name: pub_publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v4
+      - name: 🎯 Setup Dart
+        uses: dart-lang/setup-dart@v1
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2
+      - name: 📦 Install Dependencies
+        run: flutter pub get
+      - name: 🌵 Dry Run
+        run: dart pub publish --dry-run
+      - name: 📢 Publish
+        run: dart pub publish --force


### PR DESCRIPTION
## Description
This pull request introduces a new GitHub Actions workflow to automate the publishing process for Dart and Flutter packages. The workflow is triggered by a push to tags that follow semantic versioning.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore