### PR TITLE
Check listener state before set new value

### DIFF
--- a/lib/src/page_fetcher.dart
+++ b/lib/src/page_fetcher.dart
@@ -48,6 +48,12 @@ class PageFetcher<Key, Value> extends ValueNotifier<PagingState<Key, Value>> {
     return super.dispose();
   }
 
+  @override
+  set value(PagingState<Key, Value> newValue) {
+    if (!hasListeners) return;
+    super.value = newValue;
+  }
+
   Future<void> load(LoadType loadType) {
     return switch (loadType) {
       LoadType.refresh => _doInitialLoad(),


### PR DESCRIPTION
## Description

Check `ValueNotifier` disposed state before set new value. Sometimes, the cancellation callback is triggered after closing the screen (pager were disposed) hence triggering exception.

## Type of Change

- [❌ ] ✨ New feature (non-breaking change which adds functionality)
- [✅] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [❌] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [✅] 🧹 Code refactor
- [❌] ✅ Build configuration change
- [❌] 📝 Documentation
- [❌] 🗑️ Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized state management efficiency to reduce unnecessary updates and improve application performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->